### PR TITLE
add addition of jpg extension to URI path for proof back in

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/ProofModeUtil.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/ProofModeUtil.kt
@@ -127,7 +127,7 @@ object ProofModeUtil {
   fun getProofHash(context: Context, uri: Uri, byteArray: ByteArray, mimeType: String): String {
     val isEnabled = PreferenceManager.getDefaultSharedPreferences(context).getBoolean(IS_PROOF_ENABLED, true)
     return if (isEnabled) {
-      val proofHash = ProofMode.generateProof(context, uri, byteArray, mimeType)
+      val proofHash = ProofMode.generateProof(context, Uri.parse("$uri.jpg"), byteArray, mimeType)
       ProofMode.getProofDir(context, proofHash)
       photoByteArray = byteArray
 


### PR DESCRIPTION

### Description
appends ".jpg" extension to photo URIs shared with generateProof() call so that verification systems can more easily match proof.json data with the media jpg file.